### PR TITLE
feat: ERD에 대응하는 모든 Entity 구현

### DIFF
--- a/src/main/java/kr/flab/momukji/entity/Category.java
+++ b/src/main/java/kr/flab/momukji/entity/Category.java
@@ -1,0 +1,38 @@
+package kr.flab.momukji.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table
+@Getter
+@Builder
+public class Category {
+    @Id
+    @Column(name = "category_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", length = 50, unique = true, nullable = false)
+    private String name;
+
+    @CreationTimestamp
+    @Column(name = "created_timestamp", nullable = false)
+    private LocalDateTime createdTimestamp;
+
+    @UpdateTimestamp
+    @Column(name = "updated_timestamp", nullable = false)
+    private LocalDateTime updatedTimestamp;
+}

--- a/src/main/java/kr/flab/momukji/entity/Order.java
+++ b/src/main/java/kr/flab/momukji/entity/Order.java
@@ -1,0 +1,70 @@
+package kr.flab.momukji.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table
+@Getter
+@Builder
+public class Order {
+    @Id
+    @Column(name = "order_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(targetEntity = User.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(targetEntity = Store.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @Column(name = "status", nullable = false)
+    private Long status;
+
+    @Column(name = "is_delivery", nullable = false)
+    private Boolean isDelivery;
+
+    @Column(name = "message", length = 100, nullable = false)
+    private String message;
+
+    @Column(name = "estimated_minutes", nullable = false)
+    private Long estimatedMinutes;
+
+    @CreationTimestamp
+    @Column(name = "created_timestamp", nullable = false)
+    private LocalDateTime createdTimestamp;
+
+    @Column(name = "accepted_timestamp", nullable = true)
+    private LocalDateTime acceptedTimestamp;
+
+    @Column(name = "cooked_timestamp", nullable = true)
+    private LocalDateTime cookedTimestamp;
+
+    @Column(name = "pickuped_timestamp", nullable = true)
+    private LocalDateTime pickupedTimestamp;
+
+    @Column(name = "completed_timestamp", nullable = true)
+    private LocalDateTime completedTimestamp;
+
+    @UpdateTimestamp
+    @Column(name = "updated_timestamp", nullable = false)
+    private LocalDateTime updatedTimestamp;
+}

--- a/src/main/java/kr/flab/momukji/entity/Product.java
+++ b/src/main/java/kr/flab/momukji/entity/Product.java
@@ -1,0 +1,53 @@
+package kr.flab.momukji.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table
+@Getter
+@Builder
+public class Product {
+    @Id
+    @Column(name = "product_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(targetEntity = Store.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @Column(name = "name", length = 50, nullable = false)
+    private String name;
+
+    @Column(name = "price", nullable = false)
+    private Long price;
+
+    @ColumnDefault("false")
+    @Column(name = "deleted", nullable = false)
+    private Boolean deleted;
+
+    @CreationTimestamp
+    @Column(name = "created_timestamp", nullable = false)
+    private LocalDateTime createdTimestamp;
+
+    @UpdateTimestamp
+    @Column(name = "updated_timestamp", nullable = false)
+    private LocalDateTime updatedTimestamp;
+}

--- a/src/main/java/kr/flab/momukji/entity/Region.java
+++ b/src/main/java/kr/flab/momukji/entity/Region.java
@@ -1,0 +1,38 @@
+package kr.flab.momukji.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table
+@Getter
+@Builder
+public class Region {
+    @Id
+    @Column(name = "region_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", length = 50, unique = true, nullable = false)
+    private String name;
+
+    @CreationTimestamp
+    @Column(name = "created_timestamp", nullable = false)
+    private LocalDateTime createdTimestamp;
+
+    @UpdateTimestamp
+    @Column(name = "updated_timestamp", nullable = false)
+    private LocalDateTime updatedTimestamp;
+}

--- a/src/main/java/kr/flab/momukji/entity/Rider.java
+++ b/src/main/java/kr/flab/momukji/entity/Rider.java
@@ -1,0 +1,43 @@
+package kr.flab.momukji.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table
+@Getter
+@Builder
+public class Rider {
+    @Id
+    @Column(name = "rider_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "is_working", nullable = true)
+    private Boolean isWorking;
+
+    @ColumnDefault("false")
+    @Column(name = "deleted", nullable = false)
+    private Boolean deleted;
+
+    @CreationTimestamp
+    @Column(name = "created_timestamp", nullable = false)
+    private LocalDateTime createdTimestamp;
+
+    @UpdateTimestamp
+    @Column(name = "updated_timestamp", nullable = false)
+    private LocalDateTime updatedTimestamp;
+}

--- a/src/main/java/kr/flab/momukji/entity/Store.java
+++ b/src/main/java/kr/flab/momukji/entity/Store.java
@@ -1,0 +1,63 @@
+package kr.flab.momukji.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+
+@Table
+@Getter
+@Builder
+public class Store {
+    @Id
+    @Column(name = "store_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(targetEntity = StoreInfo.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "info_id", nullable = true)
+    private StoreInfo info;
+
+    @ManyToOne(targetEntity = Region.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id", nullable = false)
+    private Region region;
+
+    @ManyToOne(targetEntity = Category.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Column(name = "name", length = 50, nullable = false)
+    private String name;
+
+    @ColumnDefault("false")
+    @Column(name = "is_open", nullable = false)
+    private Boolean isOpen;
+
+    @ColumnDefault("false")
+    @Column(name = "deleted", nullable = false)
+    private Boolean deleted;
+
+    @CreationTimestamp
+    @Column(name = "created_timestamp", nullable = false)
+    private LocalDateTime createdTimestamp;
+
+    @UpdateTimestamp
+    @Column(name = "updated_timestamp", nullable = false)
+    private LocalDateTime updatedTimestamp;
+}

--- a/src/main/java/kr/flab/momukji/entity/StoreInfo.java
+++ b/src/main/java/kr/flab/momukji/entity/StoreInfo.java
@@ -1,0 +1,64 @@
+package kr.flab.momukji.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table
+@Getter
+@Builder
+public class StoreInfo {
+    @Id
+    @Column(name = "info_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "business_president", length = 50, unique = true, nullable = false)
+    private String businessPresident;
+
+    @Column(name = "business_name", length = 50, nullable = false)
+    private String businessName;
+
+    @Column(name = "business_address", length = 100, nullable = false)
+    private String business_address;
+
+    @Column(name = "business_registration_code", length = 50, nullable = false)
+    private String businessRegistrationCode;
+
+    @Column(name = "opening_hours", length = 100, nullable = false)
+    private String openingHours;
+
+    @Column(name = "description", length = 200, nullable = false)
+    private String description;
+
+    @Column(name = "contact", length = 50, nullable = false)
+    private String contact;
+
+    @Column(name = "delivery_fee", nullable = false)
+    private Long deliveryFee;
+
+    @ColumnDefault("false")
+    @Column(name = "deleted", nullable = false)
+    private Boolean deleted;
+
+    @CreationTimestamp
+    @Column(name = "created_timestamp", nullable = false)
+    private LocalDateTime createdTimestamp;
+
+    @UpdateTimestamp
+    @Column(name = "updated_timestamp", nullable = false)
+    private LocalDateTime updatedTimestamp;
+}

--- a/src/main/java/kr/flab/momukji/entity/User.java
+++ b/src/main/java/kr/flab/momukji/entity/User.java
@@ -1,41 +1,36 @@
 package kr.flab.momukji.entity;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Table
 @Getter
-@Setter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
 public class User {
     @Id
     @Column(name = "user_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long userId;
+    private Long id;
 
     @Column(name = "email", length = 100, unique = true, nullable = false)
     private String email;
@@ -50,14 +45,20 @@ public class User {
     private String address;
 
     @ColumnDefault("0")
-    @Column(name = "money", length = 100, nullable = false)
+    @Column(name = "money", nullable = false)
     private Long money;
 
     @ColumnDefault("false")
     @Column(name = "deleted", nullable = false)
-    private boolean deleted;
+    private Boolean deleted;
 
-    // TODO store_id, rider_id FK 추가
+    @OneToOne(targetEntity = Store.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = true)
+    private Store store;
+
+    @OneToOne(targetEntity = Rider.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "rider_id", nullable = true)
+    private Store rider;
 
     @CreationTimestamp
     @Column(name = "created_timestamp", nullable = false)
@@ -65,7 +66,7 @@ public class User {
 
     @UpdateTimestamp
     @Column(name = "updated_timestamp", nullable = false)
-    private LocalDate updatedTimestamp;
+    private LocalDateTime updatedTimestamp;
 
     @ManyToMany
     @JoinTable(

--- a/src/main/java/kr/flab/momukji/service/CustomUserDetailsService.java
+++ b/src/main/java/kr/flab/momukji/service/CustomUserDetailsService.java
@@ -32,7 +32,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     private org.springframework.security.core.userdetails.User createUser(String username, User user) {
-        if (user.isDeleted()) {
+        if (user.getDeleted()) {
             throw new RuntimeException(username + " -> 활성화되어 있지 않습니다.");
         }
         List<GrantedAuthority> grantedAuthorities = user.getAuthorities().stream()


### PR DESCRIPTION
전체적인 일관성
* 엔티티 Primary Key의 변수명을 id로 통일함
* 엔티티 멤버변수 형을 참조형으로 통일함

자잘한 수정
* updatedTimestamp의 형이 LocalDate로 잘못돼있던 것 LocalDateTime으로 수정
* JWT User 엔티티에 달려있던 불필요한 어노테이션 삭제 (@Setter, @NoArgsConstructor, @AllArgsArgsConstructor)

closes #11 