### PR TITLE
Feat-Rider 배차 접수하기

### DIFF
--- a/src/main/java/kr/flab/momukji/config/SecurityConfig.java
+++ b/src/main/java/kr/flab/momukji/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
             .antMatchers("/api/authenticate").permitAll()
             .antMatchers("/api/signup").permitAll()
+            .antMatchers("/apiRider/**").permitAll()
 
             .anyRequest().authenticated()
 

--- a/src/main/java/kr/flab/momukji/config/SecurityConfig.java
+++ b/src/main/java/kr/flab/momukji/config/SecurityConfig.java
@@ -47,7 +47,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
             .antMatchers("/api/authenticate").permitAll()
             .antMatchers("/api/signup").permitAll()
-            .antMatchers("/apiRider/**").permitAll()
 
             .anyRequest().authenticated()
 

--- a/src/main/java/kr/flab/momukji/controller/RiderController.java
+++ b/src/main/java/kr/flab/momukji/controller/RiderController.java
@@ -1,0 +1,25 @@
+package kr.flab.momukji.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.flab.momukji.dto.response.common.CommonResponse;
+import kr.flab.momukji.service.RiderService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/apiRider")
+@RequiredArgsConstructor
+public class RiderController {
+    
+    private final RiderService riderService;
+
+    @PutMapping("/acceptRider")
+    @PreAuthorize("hasAnyRole('RIDER')")
+    public CommonResponse acceptDelivery(Long orderId, Long userId) {
+        return riderService.accecptDelivery(orderId,userId);
+    }
+}
+

--- a/src/main/java/kr/flab/momukji/controller/RiderController.java
+++ b/src/main/java/kr/flab/momukji/controller/RiderController.java
@@ -2,8 +2,11 @@ package kr.flab.momukji.controller;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import kr.flab.momukji.dto.request.AcceptRiderDto;
 
 import kr.flab.momukji.dto.response.common.CommonResponse;
 import kr.flab.momukji.service.RiderService;
@@ -17,9 +20,9 @@ public class RiderController {
     private final RiderService riderService;
 
     @PutMapping("/acceptRider")
-    @PreAuthorize("hasAnyRole('RIDER')")
-    public CommonResponse acceptDelivery(Long orderId, Long userId) {
-        return riderService.accecptDelivery(orderId,userId);
+    @PreAuthorize("hasAnyRole('USER')")
+    public CommonResponse acceptDelivery(@RequestBody AcceptRiderDto acceptRiderDto) {
+        return riderService.accecptDelivery(acceptRiderDto);
     }
 }
 

--- a/src/main/java/kr/flab/momukji/dto/request/AcceptRiderDto.java
+++ b/src/main/java/kr/flab/momukji/dto/request/AcceptRiderDto.java
@@ -1,0 +1,18 @@
+package kr.flab.momukji.dto.request;
+
+import javax.validation.constraints.NotNull;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AcceptRiderDto {
+
+    @NotNull
+    private Long orderId;
+
+    @NotNull
+    private Long userId;
+    
+}

--- a/src/main/java/kr/flab/momukji/dto/request/AcceptRiderDto.java
+++ b/src/main/java/kr/flab/momukji/dto/request/AcceptRiderDto.java
@@ -11,8 +11,5 @@ public class AcceptRiderDto {
 
     @NotNull
     private Long orderId;
-
-    @NotNull
-    private Long userId;
     
 }

--- a/src/main/java/kr/flab/momukji/entity/Order.java
+++ b/src/main/java/kr/flab/momukji/entity/Order.java
@@ -22,10 +22,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "Orders")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -42,6 +44,10 @@ public class Order {
     @ManyToOne(targetEntity = Store.class, fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
+
+    @ManyToOne(targetEntity = Rider.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "rider_id", nullable = false)
+    private Rider rider;
 
     @Column(name = "status", nullable = false)
     private Long status;

--- a/src/main/java/kr/flab/momukji/entity/User.java
+++ b/src/main/java/kr/flab/momukji/entity/User.java
@@ -62,7 +62,7 @@ public class User {
 
     @OneToOne(targetEntity = Rider.class, fetch = FetchType.LAZY)
     @JoinColumn(name = "rider_id", nullable = true)
-    private Store rider;
+    private Rider rider;
 
     @CreationTimestamp
     @Column(name = "created_timestamp", nullable = false)

--- a/src/main/java/kr/flab/momukji/repository/RiderRepository.java
+++ b/src/main/java/kr/flab/momukji/repository/RiderRepository.java
@@ -1,0 +1,9 @@
+package kr.flab.momukji.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.flab.momukji.entity.Rider;
+
+public interface RiderRepository extends JpaRepository<Rider, Long> {
+    
+}

--- a/src/main/java/kr/flab/momukji/service/OrderService.java
+++ b/src/main/java/kr/flab/momukji/service/OrderService.java
@@ -62,7 +62,7 @@ public class OrderService {
     public CommonResponse changeOrderInfoForRider(Long orderId, Rider rider) {
         Order order = getOrderById(orderId).get();
         order.setRider(rider);
-        order.setStatus(OrderStatus.RIDERACCETED.getStatusCode());
+        order.setStatus(OrderStatus.RIDER_ACCEPTED.getStatusCode());
         orderRepository.save(order);
 
         return new CommonResponse();
@@ -73,7 +73,7 @@ public class OrderService {
     }
 
     enum OrderStatus {
-        PENDING(0L), ACCEPTED(1L), COOKED(2L), PICKUPED(3L), COMPLETE(4L),RIDERACCETED(5L), CANCELD(-1L) ;
+        PENDING(0L), ACCEPTED(1L), COOKED(2L), PICKUPED(3L), COMPLETE(4L), RIDER_ACCEPTED(5L), CANCELD(-1L);
 
         private Long statusCode;
 

--- a/src/main/java/kr/flab/momukji/service/OrderService.java
+++ b/src/main/java/kr/flab/momukji/service/OrderService.java
@@ -14,6 +14,7 @@ import kr.flab.momukji.dto.response.common.CommonResponse;
 import kr.flab.momukji.dto.response.common.ResultCode;
 import kr.flab.momukji.entity.Order;
 import kr.flab.momukji.entity.Product;
+import kr.flab.momukji.entity.Rider;
 import kr.flab.momukji.entity.Store;
 import kr.flab.momukji.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
@@ -58,8 +59,21 @@ public class OrderService {
         return new CommonResponse();
     }
     
+    public CommonResponse changeOrderInfoForRider(Long orderId, Rider rider) {
+        Order order = getOrderById(orderId).get();
+        order.setRider(rider);
+        order.setStatus(OrderStatus.RIDERACCETED.getStatusCode());
+        orderRepository.save(order);
+
+        return new CommonResponse();
+    }
+
+    public Optional<Order> getOrderById(Long orderId) {
+        return orderRepository.findById(orderId);
+    }
+
     enum OrderStatus {
-        PENDING(0L), ACCEPTED(1L), COOKED(2L), PICKUPED(3L), COMPLETE(4L), CANCELD(-1L);
+        PENDING(0L), ACCEPTED(1L), COOKED(2L), PICKUPED(3L), COMPLETE(4L),RIDERACCETED(5L), CANCELD(-1L) ;
 
         private Long statusCode;
 

--- a/src/main/java/kr/flab/momukji/service/RiderService.java
+++ b/src/main/java/kr/flab/momukji/service/RiderService.java
@@ -17,12 +17,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RiderService {
 
+    private final UserService userService;
     private final OrderService orderService;
     
     private final RiderRepository riderRepository;
 
     public CommonResponse accecptDelivery(@Valid @RequestBody AcceptRiderDto acceptRiderDto) {
-        Rider rider = getRiderById(acceptRiderDto.getUserId()).get();
+      
+        Rider rider = getRiderById(userService.getMyUserWithAuthorities().getId()).get();
         return orderService.changeOrderInfoForRider(acceptRiderDto.getOrderId(), rider);
     }
 

--- a/src/main/java/kr/flab/momukji/service/RiderService.java
+++ b/src/main/java/kr/flab/momukji/service/RiderService.java
@@ -1,0 +1,29 @@
+package kr.flab.momukji.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import kr.flab.momukji.dto.response.common.CommonResponse;
+import kr.flab.momukji.entity.Rider;
+import kr.flab.momukji.repository.RiderRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RiderService {
+
+    private final OrderService orderService;
+    
+    private final RiderRepository riderRepository;
+
+    public CommonResponse accecptDelivery(Long orderId, Long userId) {
+        Rider rider = getRiderById(userId).get();
+        return orderService.changeOrderInfoForRider(orderId, rider);
+    }
+
+    public Optional<Rider> getRiderById(Long riderId) {
+        return riderRepository.findById(riderId);
+    }
+}
+

--- a/src/main/java/kr/flab/momukji/service/RiderService.java
+++ b/src/main/java/kr/flab/momukji/service/RiderService.java
@@ -2,8 +2,12 @@ package kr.flab.momukji.service;
 
 import java.util.Optional;
 
-import org.springframework.stereotype.Service;
+import javax.validation.Valid;
 
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import kr.flab.momukji.dto.request.AcceptRiderDto;
 import kr.flab.momukji.dto.response.common.CommonResponse;
 import kr.flab.momukji.entity.Rider;
 import kr.flab.momukji.repository.RiderRepository;
@@ -17,9 +21,9 @@ public class RiderService {
     
     private final RiderRepository riderRepository;
 
-    public CommonResponse accecptDelivery(Long orderId, Long userId) {
-        Rider rider = getRiderById(userId).get();
-        return orderService.changeOrderInfoForRider(orderId, rider);
+    public CommonResponse accecptDelivery(@Valid @RequestBody AcceptRiderDto acceptRiderDto) {
+        Rider rider = getRiderById(acceptRiderDto.getUserId()).get();
+        return orderService.changeOrderInfoForRider(acceptRiderDto.getOrderId(), rider);
     }
 
     public Optional<Rider> getRiderById(Long riderId) {


### PR DESCRIPTION
* 주요사항
Put/acceptRider 구현
- RiderController
- RiderService acceptDelivery : rider정보가져와서 order 정보변경을 위한 작업하기
- OrderService changeOrerInfoForRider : 라이더 정보 넣어주고 주문 상태를 배차완료상태로 변경
- RiderRepository, RiderService getRiderById

* 기타
- Order 엔티티의 rider fk 넣어주기
- User 엔티티의 Store rider -> Rider rider로 변경
- SecurityConfig의 ("/apiRider/**")에 대한 접근허용 추가